### PR TITLE
Fix NullPointerException in MuxBaseSDKTheoPlayer.handleAdBreakStarted when release has already been called

### DIFF
--- a/muxstatssdktheoplayer/src/main/java/com/mux/stats/sdk/muxstats/theoplayer/MuxBaseSDKTheoPlayer.java
+++ b/muxstatssdktheoplayer/src/main/java/com/mux/stats/sdk/muxstats/theoplayer/MuxBaseSDKTheoPlayer.java
@@ -334,7 +334,7 @@ public class MuxBaseSDKTheoPlayer extends EventBus implements IPlayerListener {
     }
 
     private void handleAdBreakStarted(String adId, String adCreativeId) {
-      if (player.get() == null) {
+      if (player == null || player.get() == null) {
         return;
       }
 
@@ -669,6 +669,9 @@ public class MuxBaseSDKTheoPlayer extends EventBus implements IPlayerListener {
     }
 
     protected void seeking() {
+        if (player == null || player.get() == null) {
+            return;
+        }
         if ((state ==  PlayerState.INIT && player.get().getPlayer().isAutoplay())
             || (isPaused() && numberOfPlayEventsSent < 2 && state == PlayerState.PLAY )
             || state == PlayerState.SEEKING


### PR DESCRIPTION
We noticed a crash in the SDK due to a race condition. When the release method is called before handleAdBreakStarted, player == null and an exception is thrown when accessing player.get().

We also applied this fix to the seeking method, since a similar scenario seems possible.