### PR TITLE
Update theoplayer from v5->v7 + update dependencies + fix unit test

### DIFF
--- a/.github/workflows/saucelabs-tests-push.yml
+++ b/.github/workflows/saucelabs-tests-push.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        player_version: [ 'v5' ]
+        player_version: [ 'v7' ]
 
     env:
       app_artifact: automatedtests\/buildout\/outputs\/apk\/${{ matrix.player_version }}\/debug\/automatedtests-${{ matrix.player_version }}-debug.apk

--- a/.github/workflows/saucelabs-tests-release.yml
+++ b/.github/workflows/saucelabs-tests-release.yml
@@ -48,8 +48,8 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        # only run v5 for now, the v2 versions are very old
-        player_version: [ 'v5' ]
+        # only run v7 for now, the v2 versions are very old
+        player_version: [ 'v7' ]
 
     env:
       app_artifact: automatedtests\/buildout\/outputs\/apk\/${{ matrix.player_version }}\/debug\/automatedtests-${{ matrix.player_version }}-debug.apk

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -62,15 +62,15 @@ android {
 dependencies {
   implementation "androidx.multidex:multidex:2.0.1"
   implementation "com.android.support:multidex:1.0.3"
-  implementation "com.google.android.material:material:1.8.0"
-  api "org.checkerframework:checker-qual:3.32.0"
+  implementation "com.google.android.material:material:1.12.0"
+  api "org.checkerframework:checker-qual:3.33.0"
   implementation project(":muxstatssdktheoplayer")
 
   // Test against a specific version for consistent tests
-  implementation "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:5.9.1"
-  implementation 'com.theoplayer.theoplayer-sdk-android:core:5.9.1'
+  implementation "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:${project.ext.theoplayerVersion}"
+  implementation "com.theoplayer.theoplayer-sdk-android:core:${project.ext.theoplayerVersion}"
 
-  implementation "com.google.code.gson:gson:2.9.1"
-  implementation "androidx.constraintlayout:constraintlayout:2.2.0-alpha09"
+  implementation "com.google.code.gson:gson:2.10.1"
+  implementation "androidx.constraintlayout:constraintlayout:2.2.0-alpha13"
   implementation "androidx.appcompat:appcompat:1.6.1"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ android {
     }
   }
   sourceSets {
-    v5 {
+    v7 {
       java.srcDirs = ["./src/no_ads/java"]
       res.srcDirs = ["./src/no_ads/res"]
       assets.srcDirs = ["./src/no_ads/assets"]
@@ -41,7 +41,7 @@ android {
   flavorDimensions "api"
 
   productFlavors {
-    v5 {
+    v7 {
       dimension 'api'
       minSdkVersion 21
     }

--- a/app/src/no_ads/java/com/mux/stats/sdk/muxstats/theoplayer/demo/MainActivity.java
+++ b/app/src/no_ads/java/com/mux/stats/sdk/muxstats/theoplayer/demo/MainActivity.java
@@ -22,7 +22,6 @@ import com.theoplayer.android.api.source.SourceType;
 import com.theoplayer.android.api.source.TypedSource;
 import com.theoplayer.android.api.source.addescription.AdDescription;
 import com.theoplayer.android.api.source.addescription.GoogleImaAdDescription;
-import com.theoplayer.android.api.source.addescription.THEOplayerAdDescription;
 
 public class MainActivity extends AppCompatActivity {
 
@@ -89,7 +88,7 @@ public class MainActivity extends AppCompatActivity {
         // Coupling the orientation of the device with the fullscreen state.
         // The player will go fullscreen when the device is rotated to landscape
         // and will also exit fullscreen when the device is rotated back to portrait.
-        theoPlayerView.getSettings().setFullScreenOrientationCoupled(true);
+        theoPlayerView.getFullScreenManager().setFullScreenOrientationCoupled(true);
         theoPlayer.addIntegration(GoogleImaIntegrationFactory.createGoogleImaIntegration(theoPlayerView));
 
          //Creating a TypedSource builder that defines the location of a single stream source.

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -55,7 +55,7 @@ android {
   flavorDimensions "api"
 
   productFlavors {
-    v5 {
+    v7 {
       dimension 'api'
       minSdkVersion 21
     }

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -76,17 +76,17 @@ dependencies {
   implementation "androidx.multidex:multidex:2.0.1"
   implementation "com.android.support:multidex:1.0.3"
   implementation "androidx.appcompat:appcompat:1.6.1"
-  implementation "com.google.android.material:material:1.8.0"
+  implementation "com.google.android.material:material:1.12.0"
   implementation "androidx.constraintlayout:constraintlayout:2.1.4"
-  implementation "androidx.navigation:navigation-fragment:2.5.3"
-  implementation "androidx.navigation:navigation-ui:2.5.3"
-  implementation "com.google.code.gson:gson:2.9.1"
+  implementation "androidx.navigation:navigation-fragment:2.7.7"
+  implementation "androidx.navigation:navigation-ui:2.7.7"
+  implementation "com.google.code.gson:gson:2.10.1"
   androidTestImplementation "androidx.test:runner:1.5.2"
   androidTestUtil "androidx.test:orchestrator:1.4.2"
 
   // Test against a specific version for consistent tests
-  implementation 'com.theoplayer.theoplayer-sdk-android:integration-ads-ima:5.9.1'
-  implementation 'com.theoplayer.theoplayer-sdk-android:core:5.9.1'
+  implementation "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:${project.ext.theoplayerVersion}"
+  implementation "com.theoplayer.theoplayer-sdk-android:core:${project.ext.theoplayerVersion}"
 
   androidTestImplementation "androidx.test:rules:1.5.0"
   // Optional -- Hamcrest library
@@ -94,10 +94,10 @@ dependencies {
   // Optional -- UI testing with Espresso
   androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
   // Optional -- UI testing with UI Automator
-  androidTestImplementation "androidx.test.uiautomator:uiautomator:2.2.0"
+  androidTestImplementation "androidx.test.uiautomator:uiautomator:2.3.0"
   androidTestImplementation "androidx.test.ext:junit:1.1.5"
 
   implementation project(":muxstatssdktheoplayer")
-  implementation "com.google.android.gms:play-services-auth:20.5.0"
+  implementation "com.google.android.gms:play-services-auth:21.1.1"
   implementation "com.google.android.gms:play-services-ads-identifier:18.0.1"
 }

--- a/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/PlaybackTests.java
+++ b/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/PlaybackTests.java
@@ -107,10 +107,9 @@ public class PlaybackTests extends TestBase {
                 double seekToInFuture = currentPlaybackPosition + ((videoDuration - currentPlaybackPosition) / 2);
                 TimeRanges onBuffer = pView.getPlayer().getBuffered();
                 TimeRanges seekable = pView.getPlayer().getSeekable();
-                pView.getPlayer().setCurrentTime( seekToInFuture, () -> {
-                    Log.w(TAG, "Seek in the future completed");
-                    seekCompleted.set(true);
-                } );
+                pView.getPlayer().setCurrentTime(seekToInFuture);
+                Log.w(TAG, "Seek in the future completed");
+                seekCompleted.set(true);
             });
 
             // Play another x seconds, stage 7

--- a/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/ui/SimplePlayerTestActivity.java
+++ b/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/ui/SimplePlayerTestActivity.java
@@ -32,7 +32,6 @@ import com.theoplayer.android.api.source.SourceType;
 import com.theoplayer.android.api.source.TypedSource;
 import com.theoplayer.android.api.source.addescription.AdDescription;
 import com.theoplayer.android.api.source.addescription.GoogleImaAdDescription;
-import com.theoplayer.android.api.source.addescription.THEOplayerAdDescription;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         classpath 'com.novoda:bintray-release:0.9.1'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4+"
         classpath 'com.mux.gradle.android:mux-android-distribution:1.0.3'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24"
     }
 }
 
@@ -36,12 +36,12 @@ allprojects {
 
     project.ext {
         minSdkVersion=16
-        compileSdkVersion=33
-        targetSdkVersion=33
+        compileSdkVersion=34
+        targetSdkVersion=34
         releaseWebsite = 'https://github.com/muxinc/mux-stats-sdk-theoplayer-android'
 
-        theoplayerVersion = "2.92.0"
-        muxCoreVersion = "7.8.0"
+        theoplayerVersion = "7.2.0"
+        muxCoreVersion = "8.0.0"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 06 16:07:41 PST 2022
+#Wed May 08 11:01:50 CEST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/muxstatssdktheoplayer/build.gradle
+++ b/muxstatssdktheoplayer/build.gradle
@@ -32,7 +32,7 @@ android {
   flavorDimensions 'api'
 
   productFlavors {
-    v5 {
+    v7 {
       dimension 'api'
       minSdkVersion 21
     }
@@ -68,8 +68,8 @@ muxDistribution {
 dependencies {
   implementation 'com.android.support:multidex:1.0.3'
   //noinspection GradleDynamicVersion // THEO claims there will be no breaking changes.
-  v5Api "com.theoplayer.theoplayer-sdk-android:core:${project.ext.theoplayerVersion}"
-  v5Api "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:${project.ext.theoplayerVersion}"
+  v7Api "com.theoplayer.theoplayer-sdk-android:core:${project.ext.theoplayerVersion}"
+  v7Api "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:${project.ext.theoplayerVersion}"
   //noinspection GradleDependency,GradleDynamicVersion // Old kotlin asked for by name in docs
 
 //  compileOnly 'com.google.ads.interactivemedia.v3:interactivemedia:3.31.0'

--- a/muxstatssdktheoplayer/build.gradle
+++ b/muxstatssdktheoplayer/build.gradle
@@ -68,10 +68,9 @@ muxDistribution {
 dependencies {
   implementation 'com.android.support:multidex:1.0.3'
   //noinspection GradleDynamicVersion // THEO claims there will be no breaking changes.
-  v5Api "com.theoplayer.theoplayer-sdk-android:core:5.9.1"
-  v5Api "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:5.9.1"
+  v5Api "com.theoplayer.theoplayer-sdk-android:core:${project.ext.theoplayerVersion}"
+  v5Api "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:${project.ext.theoplayerVersion}"
   //noinspection GradleDependency,GradleDynamicVersion // Old kotlin asked for by name in docs
-  v5Api 'org.jetbrains.kotlin:kotlin-stdlib:1.6.+'
 
 //  compileOnly 'com.google.ads.interactivemedia.v3:interactivemedia:3.31.0'
 //  compileOnly 'com.google.android.gms:play-services-ads-identifier:18.0.1'


### PR DESCRIPTION
We updated the player to v7 and we updated some dependencies.
We also noticed that the ads test suite was failing and we applied a fix for this as well.

The build variant has also been updated from v5->v7. We have done this to avoid confusion.
But we're not sure if this is necessary/required / suitable to change this for new player releases.