### PR TITLE
fix: artifacts uploaded with incorrect names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.5.2'
-        classpath 'com.mux.gradle.android:mux-android-distribution:1.2.1'
+        classpath 'com.mux.gradle.android:mux-android-distribution:1.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24"
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -54,7 +54,7 @@ android {
 muxDistribution {
   devVersion versionFromCommitHash('dev-')
   releaseVersion versionFromTag()
-  artifactIds artifactFromFlavorValue('api')
+  artifactIds just("muxstatssdktheoplayer_v7")
   groupIds just("com.mux.stats.sdk.muxstats")
   publishIf { it.containsIgnoreCase("release") }
   publicReleaseIf releaseIfCmdFlag("publicRelease")

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -54,7 +54,7 @@ android {
 muxDistribution {
   devVersion versionFromCommitHash('dev-')
   releaseVersion versionFromTag()
-  artifactIds just("muxstatssdktheoplayer_v7")
+  artifactIds just("muxstatssdktheoplayer")
   groupIds just("com.mux.stats.sdk.muxstats")
   publishIf { it.containsIgnoreCase("release") }
   publicReleaseIf releaseIfCmdFlag("publicRelease")

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -54,7 +54,7 @@ android {
 muxDistribution {
   devVersion versionFromCommitHash('dev-')
   releaseVersion versionFromTag()
-  artifactIds just("muxstatssdktheoplayer")
+  artifactIds just("muxstatssdktheoplayer_v7")
   groupIds just("com.mux.stats.sdk.muxstats")
   publishIf { it.containsIgnoreCase("release") }
   publicReleaseIf releaseIfCmdFlag("publicRelease")


### PR DESCRIPTION
This was left-over from the buildkite migration. The artifact IDs being uploaded were incorrect