### PR TITLE
Use correct THEOPlayer error code + update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ android {
     }
   }
   sourceSets {
-    v7 {
+    v8 {
       java.srcDirs = ["./src/no_ads/java"]
       res.srcDirs = ["./src/no_ads/res"]
       assets.srcDirs = ["./src/no_ads/assets"]
@@ -41,7 +41,7 @@ android {
   flavorDimensions "api"
 
   productFlavors {
-    v7 {
+    v8 {
       dimension 'api'
       minSdkVersion 21
     }

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -56,7 +56,7 @@ android {
   flavorDimensions "api"
 
   productFlavors {
-    v7 {
+    v8 {
       dimension 'api'
       minSdkVersion 21
     }

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ allprojects {
     repositories {
         google()
         jcenter()
-        maven { url 'https://jitpack.io' }
+        maven { url "https://maven.theoplayer.com/releases" }
 
         maven { url 'https://muxinc.jfrog.io/artifactory/default-maven-release-local' }
         maven { url 'https://muxinc.jfrog.io/artifactory/default-maven-local' }
@@ -36,8 +36,8 @@ allprojects {
         targetSdkVersion=34
         releaseWebsite = 'https://github.com/muxinc/mux-stats-sdk-theoplayer-android'
 
-        theoplayerVersion = "7.2.0"
-        muxCoreVersion = "8.1.0"
+        theoplayerVersion = "8.9.0"
+        muxCoreVersion = "8.2.0"
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -35,7 +35,7 @@ android {
   flavorDimensions 'api'
 
   productFlavors {
-    v7 {
+    v8 {
       dimension 'api'
       minSdkVersion 21
     }
@@ -77,8 +77,8 @@ muxDistribution {
 dependencies {
   implementation 'com.android.support:multidex:1.0.3'
   //noinspection GradleDynamicVersion // THEO claims there will be no breaking changes.
-  v7Api "com.theoplayer.theoplayer-sdk-android:core:${project.ext.theoplayerVersion}"
-  v7Api "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:${project.ext.theoplayerVersion}"
+  v8Api "com.theoplayer.theoplayer-sdk-android:core:${project.ext.theoplayerVersion}"
+  v8Api "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:${project.ext.theoplayerVersion}"
 
   testImplementation 'junit:junit:4.13.2'
 

--- a/library/src/main/java/com/mux/stats/sdk/muxstats/theoplayer/MuxBaseSDKTheoPlayer.java
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/theoplayer/MuxBaseSDKTheoPlayer.java
@@ -56,6 +56,7 @@ import com.mux.stats.sdk.muxstats.MuxSDKViewPresentation;
 import com.mux.stats.sdk.muxstats.MuxStats;
 import com.theoplayer.android.api.THEOplayerView;
 import com.theoplayer.android.api.ads.ima.GoogleImaAdEventType;
+import com.theoplayer.android.api.error.THEOplayerException;
 import com.theoplayer.android.api.event.EventListener;
 import com.theoplayer.android.api.event.ads.AdsEventTypes;
 import com.theoplayer.android.api.event.player.PlayerEventTypes;
@@ -270,8 +271,8 @@ public class MuxBaseSDKTheoPlayer extends EventBus implements IPlayerListener {
         }));
 
         player.addEventListener(PlayerEventTypes.ERROR, (errorEvent -> {
-            internalError(
-                    new MuxErrorException(0, errorEvent.getErrorObject().getLocalizedMessage()));
+            THEOplayerException theoError = errorEvent.getErrorObject();
+            internalError(new MuxErrorException(theoError.getCode().getId(), theoError.getMessage()));
         }));
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////   Ads listeners  /////////////////////////////////////////////////////////////


### PR DESCRIPTION
Currently the Android SDK is always sending status code 0 for an error, while other platforms are using the correct TheoPlayer error code.
We also did update the TheoPlayer + new maven location + mux core to the latest version.