### PR TITLE
Fix  | Source Duration

### DIFF
--- a/library/src/main/java/com/mux/stats/sdk/muxstats/theoplayer/MuxBaseSDKTheoPlayer.java
+++ b/library/src/main/java/com/mux/stats/sdk/muxstats/theoplayer/MuxBaseSDKTheoPlayer.java
@@ -210,6 +210,10 @@ public class MuxBaseSDKTheoPlayer extends EventBus implements IPlayerListener {
                     }
                 });
 
+        player.addEventListener(PlayerEventTypes.LOADEDMETADATA) {
+            sourceDuration = playerView.player.duration
+        }
+
         player.addEventListener(PlayerEventTypes.PLAY, (playEvent -> {
             Player currentPlayer = getCurrentPlayer();
             if (currentPlayer != null && !currentPlayer.isAutoplay()


### PR DESCRIPTION
## Problem
 > The Source Duration of videos are updating incorrect. The video i played is about 2 minutes and something and it gave 0.6 seconds as duration.

## Fix
> Adds another check for source duration to get it from `LOADMEATADATA` event.
 
## Screenshots
<img width="446" height="335" alt="image" src="https://github.com/user-attachments/assets/94f87e1d-5674-487e-8453-16d11ffef175" />


cc: @daytime-em @jsanford8 @com6056 @uyt95 @tomkordic @nbirkenshaw-mux @ulyssesdotcodes @roelwuytens 