### PR TITLE
Releases/v0.8.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ android {
     }
   }
   sourceSets {
-    v10 {
+    v11 {
       java.srcDirs = ["./src/no_ads/java"]
       res.srcDirs = ["./src/no_ads/res"]
       assets.srcDirs = ["./src/no_ads/assets"]
@@ -41,7 +41,7 @@ android {
   flavorDimensions "api"
 
   productFlavors {
-    v10 {
+    v11 {
       dimension 'api'
       minSdkVersion project.ext.minSdkVersion
     }
@@ -50,6 +50,7 @@ android {
   compileOptions {
     sourceCompatibility = "1.8"
     targetCompatibility = "1.8"
+    coreLibraryDesugaringEnabled = true
   }
   lint {
     abortOnError false
@@ -60,6 +61,8 @@ android {
 }
 
 dependencies {
+  coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
+
   implementation "androidx.multidex:multidex:2.0.1"
   implementation "com.android.support:multidex:1.0.3"
   implementation "com.google.android.material:material:1.13.0"

--- a/automatedtests/build.gradle
+++ b/automatedtests/build.gradle
@@ -56,7 +56,7 @@ android {
   flavorDimensions "api"
 
   productFlavors {
-    v10 {
+    v11 {
       dimension 'api'
       minSdkVersion project.ext.minSdkVersion
     }
@@ -65,6 +65,7 @@ android {
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+    coreLibraryDesugaringEnabled = true
   }
   lint {
     abortOnError false
@@ -74,6 +75,8 @@ android {
 }
 
 dependencies {
+  coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:2.1.5"
+
   implementation "androidx.multidex:multidex:2.0.1"
   implementation "com.android.support:multidex:1.0.3"
   implementation "androidx.appcompat:appcompat:1.7.1"

--- a/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/ui/SimplePlayerTestActivity.java
+++ b/automatedtests/src/androidTest/java/com/mux/stats/sdk/muxstats/automatedtests/ui/SimplePlayerTestActivity.java
@@ -17,14 +17,8 @@ import com.mux.stats.sdk.muxstats.automatedtests.BuildConfig;
 import com.mux.stats.sdk.muxstats.automatedtests.R;
 import com.mux.stats.sdk.muxstats.automatedtests.mockup.MockNetworkRequest;
 import com.theoplayer.android.api.ads.ima.GoogleImaIntegrationFactory;
-import com.theoplayer.android.api.event.Event;
-import com.theoplayer.android.api.event.ads.AdErrorEvent;
-import com.theoplayer.android.api.event.ads.AdEvent;
 import com.theoplayer.android.api.event.ads.AdsEventTypes;
-import com.theoplayer.android.api.event.player.ErrorEvent;
 import com.theoplayer.android.api.event.player.PlayerEventTypes;
-import com.theoplayer.android.api.event.player.ReadyStateChangeEvent;
-import com.theoplayer.android.api.event.player.TimeUpdateEvent;
 import com.theoplayer.android.api.player.Player;
 import com.theoplayer.android.api.player.ReadyState;
 import com.theoplayer.android.api.source.SourceDescription;
@@ -215,24 +209,22 @@ public class SimplePlayerTestActivity extends AppCompatActivity
             }
         });
 
-        player.addEventListener(PlayerEventTypes.PLAYING, (Event event) -> {
+        player.addEventListener(PlayerEventTypes.PLAYING,  event -> {
             Log.e(TAG, "Player: Playback started");
             signalPlaybackStarted();
         });
 
-        player.addEventListener(PlayerEventTypes.ERROR, (Event event) -> {
-            ErrorEvent errorEvent = (ErrorEvent)event;
+        player.addEventListener(PlayerEventTypes.ERROR, errorEvent -> {
             Log.e(TAG, "Got error: " + errorEvent.getErrorObject().getLocalizedMessage());
         });
 
-        player.addEventListener(PlayerEventTypes.TIMEUPDATE, (Event event) -> {
-            TimeUpdateEvent timeEvent = (TimeUpdateEvent)event;
+        player.addEventListener(PlayerEventTypes.TIMEUPDATE, timeEvent -> {
             synchronized ( SimplePlayerTestActivity.this ) {
                 currentPosition = timeEvent.getCurrentTime();
             }
         });
 
-        player.addEventListener(PlayerEventTypes.ENDED, (Event event) -> {
+        player.addEventListener(PlayerEventTypes.ENDED, event -> {
             signalPlaybackEnded();
         });
     }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
         targetSdkVersion=36
         releaseWebsite = 'https://github.com/muxinc/mux-stats-sdk-theoplayer-android'
 
-        theoplayerVersion = "10.8.0"
+        theoplayerVersion = "11.2.0"
         muxCoreVersion = "8.4.1"
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -35,7 +35,7 @@ android {
   flavorDimensions 'api'
 
   productFlavors {
-    v10 {
+    v11 {
       dimension 'api'
       minSdkVersion project.ext.minSdkVersion
     }
@@ -44,6 +44,7 @@ android {
   compileOptions {
     sourceCompatibility = '1.8'
     targetCompatibility = '1.8'
+    coreLibraryDesugaringEnabled = true
   }
   lint {
     abortOnError false
@@ -75,10 +76,12 @@ muxDistribution {
 }
 
 dependencies {
+  coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
+
   implementation 'com.android.support:multidex:1.0.3'
   //noinspection GradleDynamicVersion // THEO claims there will be no breaking changes.
-  v10Api "com.theoplayer.theoplayer-sdk-android:core:${project.ext.theoplayerVersion}"
-  v10Api "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:${project.ext.theoplayerVersion}"
+  v11Api "com.theoplayer.theoplayer-sdk-android:core:${project.ext.theoplayerVersion}"
+  v11Api "com.theoplayer.theoplayer-sdk-android:integration-ads-ima:${project.ext.theoplayerVersion}"
 
   testImplementation 'junit:junit:4.13.2'
 


### PR DESCRIPTION
## Improvements

* Bump THEOPlayer to 11.2.0 (#47)



Co-authored-by: OlegRyz <aleh.ryzhankou@gmail.com>
Co-authored-by: GitHub <noreply@github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major THEOplayer SDK bump touches all modules and playback-related test code; runtime integration risk is limited in this diff to Gradle and test harness updates, not library analytics logic.
> 
> **Overview**
> **Bumps THEOplayer Android from 10.8.0 to 11.2.0** and aligns the repo with a **v11** API product flavor (replacing **v10**) in `app`, `library`, and `automatedtests`.
> 
> **Build tooling:** enables **core library desugaring** (`coreLibraryDesugaringEnabled` + `desugar_jdk_libs:2.1.5`) on those modules and wires THEOplayer **core** and **integration-ads-ima** through **`v11Api`** in the library module.
> 
> **Instrumentation tests:** `SimplePlayerTestActivity` player event listeners are updated to THEOplayer 11’s typed lambdas (e.g. `errorEvent`, `timeEvent`) instead of casting generic `Event` types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8200c959d08e341f70a6d0816b4a82269467ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->